### PR TITLE
Security: Fix side-channel vulnerability

### DIFF
--- a/include/symops.h
+++ b/include/symops.h
@@ -17,3 +17,4 @@
 
 void symcrypt(unsigned char *, unsigned char *, struct hdr *);
 void symdecrypt(unsigned char *, unsigned char *, struct hdr *);
+int cmp_const(const void * a, const void *b, const size_t size);


### PR DESCRIPTION
(This is my first contribution working with C, so please check the code.)

Fix side-channel vulnerability in `symcrypt()` under `symops.c` by comparing passwords in constant time. Function to compare in constant time is taken from [cryptocoding.net](https://cryptocoding.net/index.php/Coding_rules).